### PR TITLE
Absolute difference modules (Like thresholding, but not) and clamp max/min

### DIFF
--- a/opsi/manager/cvwrapper.py
+++ b/opsi/manager/cvwrapper.py
@@ -215,3 +215,11 @@ def joinBW(img1: MatBW, img2: MatBW) -> MatBW:
 
 def greyscale(img: Mat) -> Mat:
     return cv2.cvtColor(img.mat, cv2.COLOR_BGR2GRAY).view(Mat).mat
+
+
+def bgr_to_hsv(img: Mat) -> Mat:
+    return cv2.cvtColor(img.mat, cv2.COLOR_BGR2HSV)
+
+
+def abs_diff(img, scalar):
+    return cv2.absdiff(img, scalar)

--- a/opsi/manager/cvwrapper.py
+++ b/opsi/manager/cvwrapper.py
@@ -221,5 +221,5 @@ def bgr_to_hsv(img: Mat) -> Mat:
     return cv2.cvtColor(img.mat, cv2.COLOR_BGR2HSV)
 
 
-def abs_diff(img, scalar):
+def abs_diff(img: Mat, scalar: ndarray):
     return cv2.absdiff(img, scalar)

--- a/opsi/modules/color.py
+++ b/opsi/modules/color.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import opsi.manager.cvwrapper as cvw
 from opsi.manager.manager_schema import Function
-from opsi.manager.types import Mat, MatBW, RangeType
+from opsi.manager.types import Mat, MatBW, RangeType, Slide
 
 __package__ = "opsi.colorops"
 __version__ = "0.123"
@@ -88,12 +88,12 @@ class Canny(Function):
 class AbsoluteDifferenceRGB(Function):
     @dataclass
     class Settings:
-        red: int
-        green: int
-        blue: int
+        red: Slide(min=0, max=255, decimal=False)
+        green: Slide(min=0, max=255, decimal=False)
+        blue: Slide(min=0, max=255, decimal=False)
         to_greyscale: bool
         clamp_max: bool
-        clamp_value: int
+        clamp_value: Slide(min=0, max=255, decimal=False)
 
     @dataclass
     class Inputs:
@@ -124,14 +124,14 @@ class AbsoluteDifferenceRGB(Function):
 class AbsoluteDifferenceHSV(Function):
     @dataclass
     class Settings:
-        hue: int
+        hue: Slide(min=0, max=359, decimal=False)
         hue_sensitivity: int
-        sat: int
+        sat: Slide(min=0, max=255, decimal=False)
         sat_sensitivity: int
-        val: int
+        val: Slide(min=0, max=255, decimal=False)
         val_sensitivity: int
         clamp_max: bool
-        clamp_value: int
+        clamp_value: Slide(min=0, max=255, decimal=False)
 
     @dataclass
     class Inputs:
@@ -178,7 +178,7 @@ class AbsoluteDifferenceHSV(Function):
 class ClampMax(Function):
     @dataclass
     class Settings:
-        max_value: int
+        max_value: Slide(min=0, max=255, decimal=False)
 
     @dataclass
     class Inputs:
@@ -195,7 +195,7 @@ class ClampMax(Function):
 class ClampMin(Function):
     @dataclass
     class Settings:
-        min_value: int
+        min_value: Slide(min=0, max=255, decimal=False)
 
     @dataclass
     class Inputs:

--- a/opsi/modules/color.py
+++ b/opsi/modules/color.py
@@ -148,9 +148,10 @@ class AbsoluteDifferenceHSV(Function):
             np.array(
                 [self.settings.hue, self.settings.sat, self.settings.val],
                 dtype=np.float,
-            )[None],
+            )[None], # [None] adds a dimension to the ndarray object created by np.array() -
+                     # See https://stackoverflow.com/questions/37867354/in-numpy-what-does-selection-by-none-do
         ).view(Mat)
-
+        
         scaled_diff = np.multiply(
             diff_hsv,
             np.array(

--- a/opsi/modules/color.py
+++ b/opsi/modules/color.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+import numpy as np
+
 import opsi.manager.cvwrapper as cvw
 from opsi.manager.manager_schema import Function
 from opsi.manager.types import Mat, MatBW, RangeType
@@ -81,3 +83,127 @@ class Canny(Function):
                 inputs.img, self.settings.threshold[0], self.settings.threshold[1]
             )
         )
+
+
+class AbsoluteDifferenceRGB(Function):
+    @dataclass
+    class Settings:
+        red: int
+        green: int
+        blue: int
+        to_greyscale: bool
+        clamp_max: bool
+        clamp_value: int
+
+    @dataclass
+    class Inputs:
+        img: Mat
+
+    @dataclass
+    class Outputs:
+        img: Mat
+
+    def run(self, inputs):
+        diff = cvw.abs_diff(
+            inputs.img,
+            np.array(
+                [self.settings.blue, self.settings.green, self.settings.red],
+                dtype=np.float,
+            )[None],
+        ).view(Mat)
+
+        if self.settings.to_greyscale:
+            diff = cvw.greyscale(diff)
+
+        if self.settings.clamp_max:
+            diff = np.minimum(diff, self.settings.clamp_value)
+
+        return self.Outputs(img=diff)
+
+
+class AbsoluteDifferenceHSV(Function):
+    @dataclass
+    class Settings:
+        hue: int
+        hue_sensitivity: int
+        sat: int
+        sat_sensitivity: int
+        val: int
+        val_sensitivity: int
+        clamp_max: bool
+        clamp_value: int
+
+    @dataclass
+    class Inputs:
+        img: Mat
+
+    @dataclass
+    class Outputs:
+        img: Mat
+
+    def run(self, inputs):
+        img_hsv = cvw.bgr_to_hsv(inputs.img)
+        diff_hsv = cvw.abs_diff(
+            inputs.img,
+            np.array(
+                [self.settings.hue, self.settings.sat, self.settings.val],
+                dtype=np.float,
+            )[None],
+        ).view(Mat)
+
+        scaled_diff = np.multiply(
+            diff_hsv,
+            np.array(
+                [
+                    self.settings.hue_sensitivity,
+                    self.settings.sat_sensitivity,
+                    self.settings.val_sensitivity,
+                ],
+                dtype=np.uint16,
+            ),
+        ).astype(np.uint16)
+
+        greyscale = cvw.greyscale(scaled_diff)
+
+        if self.settings.clamp_max:
+            greyscale = np.minimum(greyscale, self.settings.clamp_value).astype(
+                np.uint8
+            )
+        else:
+            greyscale = np.minimum(greyscale, 255).astype(np.uint8)
+
+        return self.Outputs(img=greyscale)
+
+
+class ClampMax(Function):
+    @dataclass
+    class Settings:
+        max_value: int
+
+    @dataclass
+    class Inputs:
+        img: Mat
+
+    @dataclass
+    class Outputs:
+        img: Mat
+
+    def run(self, inputs):
+        return self.Outputs(img=np.minimum(inputs.img, self.settings.max_value))
+
+
+class ClampMin(Function):
+    @dataclass
+    class Settings:
+        min_value: int
+
+    @dataclass
+    class Inputs:
+        img: Mat
+
+    @dataclass
+    class Outputs:
+        img: Mat
+
+    def run(self, inputs):
+        return self.Outputs(img=np.maximum(inputs.img, self.settings.min_value))


### PR DESCRIPTION
Added modules for finding the absolute difference between each color channel of each pixel and a user-set color.
Also added clampMin and ClampMax modules to limit the brightness in a greyscale image to a minimum or maximum value.
These two combined can be used to leave a plain background except for a certain color for detecting lines/circles of that color. They are not useful for contour detection.