### PR TITLE
H.264 support through upgraded-engineer

### DIFF
--- a/opsi/manager/manager.py
+++ b/opsi/manager/manager.py
@@ -121,6 +121,10 @@ class Manager:
 
         self.modules[info.package] = ModuleItem(info, funcs)
 
+    def pipeline_update(self):
+        for hook in self.hooks.values():
+            hook.pipeline_update()
+
     def shutdown(self):
         for hook in self.hooks.values():
             hook.shutdown()

--- a/opsi/manager/manager_schema.py
+++ b/opsi/manager/manager_schema.py
@@ -35,6 +35,7 @@ def does_match(cls, name: str, asserter: Callable[[Any], bool]) -> bool:
 class Function:
     has_sideeffect: bool = False
     require_restart: bool = False
+    always_restart: bool = False
     disabled = False
     force_enabled = False
 
@@ -62,6 +63,9 @@ class Function:
 
         if not hasattr(cls, "require_restart"):
             error("property 'require_restart'")
+
+        if not hasattr(cls, "always_restart"):
+            error("property 'always_restart'")
 
         if not does_match(cls, "disabled", is_bool):
             error("bool property 'disabled'")

--- a/opsi/manager/manager_schema.py
+++ b/opsi/manager/manager_schema.py
@@ -239,6 +239,10 @@ class Hook:
         for func in self.listeners["shutdown"]:
             func()
 
+    def pipeline_update(self):
+        for func in self.listeners["pipeline_update"]:
+            func()
+
 
 def ishook(hook):
     return isinstance(hook, Hook)

--- a/opsi/manager/pipeline.py
+++ b/opsi/manager/pipeline.py
@@ -214,6 +214,10 @@ class Pipeline:
         for node in self.nodes.values():
             node.reset_links()
 
+    def dispose_all(self):
+        for node in self.nodes.values():
+            node.dispose()
+
     def prune_nodetree(self, new_node_ids):
         old_node_ids = set(self.nodes.keys())
         new_node_ids = set(new_node_ids)

--- a/opsi/manager/program.py
+++ b/opsi/manager/program.py
@@ -45,6 +45,7 @@ class Program:
             task = self.queue.get()  # todo: blocking & timeout?
             task.run()  # won't send exceptions because runs in seperate thead
         LOGGER.info("Program main loop is shutting down...")
+        self.pipeline.dispose_all()
         self.pipeline.clear()
         self.manager.shutdown()
         self.shutdown.clear()

--- a/opsi/modules/color.py
+++ b/opsi/modules/color.py
@@ -7,6 +7,7 @@ from opsi.manager.manager_schema import Function
 from opsi.manager.types import RangeType, Slide
 from opsi.util.cv import Mat, MatBW
 from opsi.util.cv.mat import Color
+from opsi.util.cv.shape import Point
 
 __package__ = "opsi.colorops"
 __version__ = "0.123"
@@ -324,3 +325,22 @@ class ColorDetector(Function):
                 output_str = hue_strings[hue]
 
         return self.Outputs(color_string=output_str)
+
+
+class Resize(Function):
+    @dataclass
+    class Settings:
+        width: int
+        height: int
+
+    @dataclass
+    class Inputs:
+        img: Mat
+
+    @dataclass
+    class Outputs:
+        img: Mat
+
+    def run(self, inputs):
+        img = inputs.img.resize(Point(self.settings.width, self.settings.height))
+        return self.Outputs(img=img)

--- a/opsi/modules/videoio/__init__.py
+++ b/opsi/modules/videoio/__init__.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass
+from typing import Tuple
+
+import engine
 
 from opsi.manager.manager_schema import Function
 from opsi.util.cv import Mat, MatBW
@@ -9,7 +12,6 @@ from .input import controls, create_capture, get_modes, parse_camstring
 
 __package__ = "opsi.videoio"
 __version__ = "0.123"
-
 
 UndupeInstance = Unduplicator()
 HookInstance = CamHook()
@@ -63,11 +65,14 @@ class CameraServer(Function):
         return settings
 
     def on_start(self):
-        self.src = CameraSource()
-        HookInstance.register(self)
+        if self.settings.backend == "MjpegCameraServer":
+            self.src = MjpegCameraServer()
+        elif self.settings.backend == "H264CameraServer":
+            self.src = H264CameraServer()
 
     @dataclass
     class Settings:
+        backend: ("MjpegCameraServer", "H264CameraServer")
         name: str = "camera"
 
     @dataclass
@@ -75,17 +80,52 @@ class CameraServer(Function):
         img: Mat
 
     def run(self, inputs):
-        if isinstance(inputs.img, MatBW):
-            self.src.img = inputs.img.mat
-        else:
-            self.src.img = inputs.img
+        self.src.run(inputs)
         return self.Outputs()
 
     def dispose(self):
-        self.src.shutdown()
-        HookInstance.unregister(self)
+        self.src.dispose()
 
     # Returns a unique string for each CameraServer instance
     @property
     def id(self):
         return self.settings.name
+
+
+class MjpegCameraServer:
+    def __init__(self):
+        self.src = CameraSource()
+        HookInstance.register(self)
+
+    def run(self, inputs):
+        if isinstance(inputs.img, MatBW):
+            self.src.img = inputs.img.mat
+        else:
+            self.src.img = inputs.img
+
+    def dispose(self):
+        self.src.shutdown()
+        HookInstance.unregister(self)
+
+
+class H264CameraServer:
+    def __init__(self):
+        self.engine: engine.GStreamerEngineWriter = None
+
+    def run(self, inputs: "CameraServer.Inputs"):
+        if self.engine is None:
+            # we need to set up engine
+            size: Tuple[int, int, int] = (*inputs.img.img.size, 30)
+            self.engine = engine.GStreamerEngineWriter(
+                video_size=size, repeat_frames=True
+            )
+            return
+        else:
+            if isinstance(inputs.img, MatBW):
+                img = inputs.img.mat
+            else:
+                img = inputs.img
+            self.engine.write_frame(img)
+
+    def dispose(self):
+        self.engine.end()

--- a/opsi/modules/videoio/__init__.py
+++ b/opsi/modules/videoio/__init__.py
@@ -5,7 +5,7 @@ from opsi.manager.manager_schema import Function
 from opsi.util.cv import Mat, MatBW
 from opsi.util.unduplicator import Unduplicator
 
-from .cameraserver import CamHook, H264CameraServer, MjpegCameraServer
+from .cameraserver import CamHook, EngineManager, H264CameraServer, MjpegCameraServer
 from .input import controls, create_capture, get_modes, parse_camstring
 
 __package__ = "opsi.videoio"
@@ -13,6 +13,7 @@ __version__ = "0.123"
 
 UndupeInstance = Unduplicator()
 HookInstance = CamHook()
+EngineInstance = EngineManager()
 
 
 class CameraInput(Function):
@@ -70,7 +71,8 @@ class CameraServer(Function):
             self.src = MjpegCameraServer()
         elif self.settings.backend == "H264CameraServer":
             self.always_restart = True
-            self.src = H264CameraServer()
+            self.src = H264CameraServer(self.settings.name, self.settings.h264_acceleration)
+            EngineInstance.add(self.src.pipeline)
 
     @dataclass
     class Settings:

--- a/opsi/modules/videoio/__init__.py
+++ b/opsi/modules/videoio/__init__.py
@@ -73,7 +73,6 @@ class CameraServer(Function):
         elif self.settings.backend == "H.264":
             self.always_restart = True
             self.src = H264CameraServer(self.settings.name)
-            EngineInstance.register(self.src)
 
     @dataclass
     class Settings:
@@ -86,13 +85,15 @@ class CameraServer(Function):
 
     def run(self, inputs):
         self.src.run(inputs)
+        if self.settings.backend == "H.264":
+            self.src.register(EngineInstance)
         return self.Outputs()
 
     def dispose(self):
         if self.settings.backend == "MJPEG":
             HookInstance.unregister(self)
         elif self.settings.backend == "H.264":
-            EngineInstance.unregister(self.src)
+            self.src.unregister(EngineInstance)
         self.src.dispose()
 
     # Returns a unique string for each CameraServer instance

--- a/opsi/modules/videoio/__init__.py
+++ b/opsi/modules/videoio/__init__.py
@@ -75,6 +75,7 @@ class CameraServer(Function):
     @dataclass
     class Settings:
         name: str = "camera"
+        h264_acceleration: bool = False
         backend: ("MjpegCameraServer", "H264CameraServer") = "MjpegCameraServer"
 
     @dataclass

--- a/opsi/modules/videoio/__init__.py
+++ b/opsi/modules/videoio/__init__.py
@@ -13,7 +13,7 @@ __version__ = "0.123"
 
 UndupeInstance = Unduplicator()
 HookInstance = CamHook()
-EngineInstance = EngineManager()
+EngineInstance = EngineManager(HookInstance)
 HookInstance.add_listener("pipeline_update", EngineInstance.restart_engine)
 
 
@@ -70,14 +70,17 @@ class CameraServer(Function):
             HookInstance.register(self)
             self.always_restart = False
             self.src = MjpegCameraServer()
-        elif self.settings.backend == "H.264":
+        elif self.settings.backend == "H.264 (30 FPS)":
             self.always_restart = True
-            self.src = H264CameraServer(self.settings.name)
+            self.src = H264CameraServer(self.settings.name, 30)
+        elif self.settings.backend == "H.264 (60 FPS)":
+            self.always_restart = True
+            self.src = H264CameraServer(self.settings.name, 60)
 
     @dataclass
     class Settings:
         name: str = "camera"
-        backend: ("MJPEG", "H.264") = "MJPEG"
+        backend: ("MJPEG", "H.264 (30 FPS)", "H.264 (60 FPS)") = "MJPEG"
 
     @dataclass
     class Inputs:
@@ -85,14 +88,14 @@ class CameraServer(Function):
 
     def run(self, inputs):
         self.src.run(inputs)
-        if self.settings.backend == "H.264":
+        if "H.264" in self.settings.backend:
             self.src.register(EngineInstance)
         return self.Outputs()
 
     def dispose(self):
         if self.settings.backend == "MJPEG":
             HookInstance.unregister(self)
-        elif self.settings.backend == "H.264":
+        elif "H.264" in self.settings.backend:
             self.src.unregister(EngineInstance)
         self.src.dispose()
 

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -3,6 +3,7 @@ import json
 import logging
 import queue
 import re
+import shlex
 import subprocess
 from datetime import datetime
 from shlex import split
@@ -430,8 +431,10 @@ class EngineManager:
     def start(self):
         # turn pipelines into JSON
         pipes = json.dumps([v for k, v in self.pipelines.items()])
-        launch = engine.core.DEFAULT_EXEC_PATH + "--pipes-as-json" + pipes
-        self.engine = engine.Engine(launch)
+        launch = "{exec_} {arg} {pipes}".format(
+            exec_=engine.core.DEFAULT_EXEC_PATH, arg="--pipes-as-json", pipes=pipes
+        )
+        self.engine = engine.Engine(shlex.split(launch))
         self.engine.start()
         self._on = True
 

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -430,7 +430,7 @@ class EngineManager:
     def start(self):
         # turn pipelines into JSON
         pipes = json.dumps([v for k, v in self.pipelines.items()])
-        launch = engine.core.DEFAULT_EXEC + "--pipes-as-json" + pipes
+        launch = engine.core.DEFAULT_EXEC_PATH + "--pipes-as-json" + pipes
         self.engine = engine.Engine(launch)
         self.engine.start()
         self._on = True

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -436,16 +436,22 @@ class EngineManager(Hook):
 
 
 class H264CameraServer:
-    def __init__(self):
+    def __init__(self, name: str, accelerate: bool = False):
+        self.name = name
+        self.omx = accelerate
+        self.size: Tuple[int, int, int] = (0, 0, 0)
         self.engine: engine.GStreamerEngineWriter = None
 
     def run(self, inputs: "CameraServer.Inputs"):
         if self.engine is None:
             # we need to set up engine
             shape = inputs.img.img.shape
-            size: Tuple[int, int, int] = (shape[1], shape[0], 30)
+            self.size: Tuple[int, int, int] = (shape[1], shape[0], 30)
             self.engine = engine.GStreamerEngineWriter(
-                video_size=size, repeat_frames=True
+                socket_path=self.shmem_socket,
+                video_size=self.size,
+                repeat_frames=True,
+                autostart=False,
             )
             return
         else:

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -453,4 +453,4 @@ class H264CameraServer:
             self.engine.write_frame(img)
 
     def dispose(self):
-        self.engine.end()
+        self.engine.stop()

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -454,3 +454,18 @@ class H264CameraServer:
 
     def dispose(self):
         self.engine.stop()
+
+    @property
+    def shmem_socket(self):
+        return "/tmp/{}".format(self.name)
+
+    @property
+    def pipeline(self):
+        encoder = "OpenMAX" if self.omx else "Software"
+        url = "/".format(self.name)
+        return {
+            "input": {"SharedMemory": self.shmem_socket},
+            "encoder": encoder,
+            "size": {"width": 320, "height": 240, "framerate": 30},
+            "url": url,
+        }

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -1,13 +1,15 @@
 import asyncio
+import json
 import logging
 import queue
 import re
 from datetime import datetime
+from typing import Tuple
 
+import engine
 import jinja2
 from starlette.routing import Route, Router
 
-import engine
 from opsi.manager.manager_schema import Hook
 from opsi.util.concurrency import AsyncThread, Snippet
 from opsi.util.cv import Mat, Point
@@ -25,6 +27,7 @@ __version__ = "0.123"
 
 LOGGER = logging.getLogger(__name__)
 logging.getLogger("asyncio").setLevel(logging.ERROR)
+
 
 # -----------------------------------------------------------------------------
 # Reusable ASGI framework

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -435,7 +435,8 @@ class EngineManager(Hook):
 
     def restart_engine(self):
         self.engine.stop()
-        self.start()
+        if len(self.pipelines) > 0:
+            self.start()
 
 
 class H264CameraServer:

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -450,6 +450,7 @@ class H264CameraServer:
         self.name = name
         self.size: Tuple[int, int, int] = (0, 0, 0)
         self.engine: engine.GStreamerEngineWriter = None
+        self.registered: bool = False
 
     def run(self, inputs: "CameraServer.Inputs"):
         if self.engine is None:
@@ -470,6 +471,18 @@ class H264CameraServer:
     def dispose(self):
         if self.engine:
             self.engine.stop()
+
+    def register(self, EngineInstance):
+        if self.registered:
+            return
+        EngineInstance.register(self)
+        self.registered = True
+
+    def unregister(self, EngineInstance):
+        if not self.registered:
+            return
+        EngineInstance.unregister(self)
+        self.registered = False
 
     @property
     def shmem_socket(self):
@@ -493,6 +506,6 @@ class H264CameraServer:
         return {
             "input": {"SharedMemory": self.shmem_socket},
             "encoder": self.encoder,
-            "size": {"width": 320, "height": 240, "framerate": 30},
+            "size": {"width": self.size[0], "height": self.size[1], "framerate": 30},
             "url": url,
         }

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -430,7 +430,7 @@ class EngineManager:
     def start(self):
         # turn pipelines into JSON
         pipes = json.dumps([v for k, v in self.pipelines.items()])
-        launch = engine.core.DEFAULT_EXEC + ["--pipes-as-json", pipes]
+        launch = engine.core.DEFAULT_EXEC + "--pipes-as-json" + pipes
         self.engine = engine.Engine(launch)
         self.engine.start()
         self._on = True

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -269,7 +269,7 @@ class CamHook(Hook):
 
     def endpoint(self, func):
         def image(request):
-            return MjpegResponse(request, func.src)
+            return MjpegResponse(request, func.src.src)
 
         return image
 
@@ -387,15 +387,12 @@ class CameraSource:
 class MjpegCameraServer:
     def __init__(self):
         self.src = CameraSource()
-        HookInstance.register(self)
 
     def run(self, inputs):
         self.src.img = inputs.img.mat
 
     def dispose(self):
-        super().dispose()
         self.src.shutdown()
-        HookInstance.unregister(self)
 
 
 class H264CameraServer:

--- a/opsi/modules/videoio/cameraserver.py
+++ b/opsi/modules/videoio/cameraserver.py
@@ -431,7 +431,7 @@ class EngineManager:
     def start(self):
         # turn pipelines into JSON
         pipes = json.dumps([v for k, v in self.pipelines.items()])
-        launch = "{exec_} {arg} {pipes}".format(
+        launch = "{exec_} {arg} '{pipes}'".format(
             exec_=engine.core.DEFAULT_EXEC_PATH, arg="--pipes-as-json", pipes=pipes
         )
         self.engine = engine.Engine(shlex.split(launch))

--- a/opsi/util/cv/mat.py
+++ b/opsi/util/cv/mat.py
@@ -83,7 +83,7 @@ class Mat:
         return Mat(a)
 
     def resize(self, res: Point) -> "Mat":
-        return Mat(cv2.resize(self, res))
+        return Mat(cv2.resize(self.img, res))
 
     def canny(self, threshold_lower, threshold_upper) -> "MatBW":
         return MatBW(cv2.Canny(self.img, threshold_lower, threshold_upper))

--- a/opsi/webserver/api.py
+++ b/opsi/webserver/api.py
@@ -40,7 +40,7 @@ class Api:
         json = {"error": "Invalid Nodetree", "message": exc.args[0]}
 
         if exc.node:
-            json.update({"node": str(exc.node.id), "type": exc.node.type})
+            json.update({"node": str(exc.node.id), "type": exc.type})
 
         return JSONResponse(status_code=400, content=json)
 

--- a/opsi/webserver/serialize.py
+++ b/opsi/webserver/serialize.py
@@ -451,6 +451,7 @@ def import_nodetree(program, nodetree: NodeTreeN):
 
         try:
             program.pipeline.run()
+            program.manager.pipeline_update()
         except Exception as e:
             program.pipeline.broken = True
             raise NodeTreeImportError(program, node, f"Failed test run due to '{e}'")

--- a/opsi/webserver/serialize.py
+++ b/opsi/webserver/serialize.py
@@ -2,18 +2,16 @@ import logging
 import sys
 from collections import deque
 from dataclasses import _MISSING_TYPE, asdict
-from typing import Callable, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from opsi.manager.link import NodeLink
 from opsi.manager.manager import Manager
 from opsi.manager.manager_schema import Function, ModuleItem
 from opsi.manager.pipeline import Connection, Link, Links, Pipeline, StaticLink
 from opsi.manager.types import *
+from opsi.manager.types import RangeType, Slide
 from opsi.util.concurrency import FifoLock
 
-from ..util.cv import Contour, Contours, Mat, MatBW, Point
-from ..util.cv.mat import Color
-from ..util.cv.shape import Circles, Lines, Segments
 from .schema import *
 
 __all__ = (
@@ -22,7 +20,6 @@ __all__ = (
     "import_nodetree",
     "NodeTreeImportError",
 )
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +45,7 @@ def _tuple_serialize(type):
     if not isinstance(type, tuple):
         return None
 
-    return InputOutputF(type="tup", params={"options": type})
+    return InputOutputF(type="box", params={"options": type})
 
 
 _type_name: Dict[Type, str] = {
@@ -56,12 +53,10 @@ _type_name: Dict[Type, str] = {
     bool: "bol",
     MatBW: "mbw",
     Circles: "cls",
-    Color: "col",
     Segments: "seg",
     Lines: "lin",
     Contour: "cnt",
     Contours: "cts",
-    Point: "pnt",
     AnyType: "any",
 }
 _normal_types = {int, str, Mat}
@@ -355,18 +350,10 @@ def _process_node_settings(program, node: NodeN):
         raise NodeTreeImportError(program, node, "Invalid settings") from e
 
     if LINKS_INSTEAD_OF_INPUTS:
-        restart = False
         if real_node.func_type.require_restart:
             if real_node.settings is not None:
                 if not real_node.settings == settings:
-                    restart = True
-        try:
-            if real_node.func.always_restart:
-                restart = True
-        except AttributeError:
-            pass
-        if restart:
-            real_node.dispose()
+                    real_node.dispose()
         if real_node.func:
             real_node.func.settings = settings
 
@@ -451,7 +438,6 @@ def import_nodetree(program, nodetree: NodeTreeN):
 
         try:
             program.pipeline.run()
-            program.manager.pipeline_update()
         except Exception as e:
             program.pipeline.broken = True
             raise NodeTreeImportError(program, node, f"Failed test run due to '{e}'")

--- a/opsi/webserver/serialize.py
+++ b/opsi/webserver/serialize.py
@@ -355,10 +355,18 @@ def _process_node_settings(program, node: NodeN):
         raise NodeTreeImportError(program, node, "Invalid settings") from e
 
     if LINKS_INSTEAD_OF_INPUTS:
+        restart = False
         if real_node.func_type.require_restart:
             if real_node.settings is not None:
                 if not real_node.settings == settings:
-                    real_node.dispose()
+                    restart = True
+        try:
+            if real_node.func.always_restart:
+                restart = True
+        except AttributeError:
+            pass
+        if restart:
+            real_node.dispose()
         if real_node.func:
             real_node.func.settings = settings
 

--- a/opsi/webserver/serialize.py
+++ b/opsi/webserver/serialize.py
@@ -227,7 +227,9 @@ def export_nodetree(pipeline: Pipeline) -> NodeTreeN:
 
 
 class NodeTreeImportError(ValueError):
-    def __init__(self, program, node: NodeN = None, msg="", *, exc_info=True):
+    def __init__(
+        self, program, node: NodeN = None, msg="", *, exc_info=True, real_node=False
+    ):
         program.pipeline.clear()
         program.pipeline.broken = True
 
@@ -242,9 +244,14 @@ class NodeTreeImportError(ValueError):
 
             msg += ": " + str(exc_info[1])
 
+        if real_node:
+            self.type = str(self.node.func_type)
+        else:
+            self.type = self.node.type
+
         logMsg = msg
         if self.node:
-            msg = f"{self.node.type}: {msg}"
+            msg = f"{self.type}: {msg}"
             logMsg = f"Node '{self.node.id}' returned error {msg}"
 
         super().__init__(msg)
@@ -454,6 +461,11 @@ def import_nodetree(program, nodetree: NodeTreeN):
             program.manager.pipeline_update()
         except Exception as e:
             program.pipeline.broken = True
-            raise NodeTreeImportError(program, node, f"Failed test run due to '{e}'")
+            raise NodeTreeImportError(
+                program,
+                program.pipeline.current,
+                f"Failed test run due to",
+                real_node=True,
+            )
 
         program.pipeline.broken = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ python-multipart==0.0.5
 six==1.12.0
 starlette==0.12.9
 toposort==1.5
-upgraded-engineer==0.1.0
+upgraded-engineer==0.2.0
 uvicorn==0.9.0
 uvloop==0.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ python-multipart==0.0.5
 six==1.12.0
 starlette==0.12.9
 toposort==1.5
-upgraded-engineer==0.2.0
+upgraded-engineer==0.2.1
 uvicorn==0.9.0
 uvloop==0.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ python-multipart==0.0.5
 six==1.12.0
 starlette==0.12.9
 toposort==1.5
-upgraded-engineer==0.0.3
+upgraded-engineer==0.1.0
 uvicorn==0.9.0
 uvloop==0.11.2


### PR DESCRIPTION
_Shh! Nobody tell CD!_

Add an H,264 mode to the CameraServer function. In the process, a few significant changes had to be made:
- `CameraServer` is now effectively a wrapper around `MjpegCameraServer`/`H264CameraServer`. Its settings are available for both, and should be "common settings" between the two with the rest being reasonable defaults.
   - [x] BIG FAT TODO: `rusty-engine` can't run multiple streams on the same port (as a "not yet a feature", not a technical limitation.) Either `rusty-engine` needs this feature added or we need to somehow pick a random unused port and show it to the user. The former honestly sounds preferable, not sure how that would look for the CLI. Right now, neither has been done. :flushed: 
  - [x] Wishlist: It'd be nice if we didn't need to lock the framerate for H.264 to 30. I don't think it's a big deal, as processing will still be at _max throttle_ but it'd be nice. 
- The minimum version of `upgraded-engineer` has been increased to `0.1.0`.