### PR TITLE
Fix variable naming error in BooleanSwitch

### DIFF
--- a/opsi/modules/logic.py
+++ b/opsi/modules/logic.py
@@ -90,8 +90,8 @@ class SwitchBoolean(Function):
 
     def run(self, inputs):
         if inputs.switch:
-            return self.Outputs(out=inputs.thru2)
-        return self.Outputs(out=inputs.thru1)
+            return self.Outputs(thru=inputs.thru1)
+        return self.Outputs(thru=inputs.thru0)
 
 
 class SwitchNumber(Function):


### PR DESCRIPTION
The variables are named thru, thru0, and thru1, but when used they are named out, thru1, thru2